### PR TITLE
Handle sub-millisecond response time

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,7 @@
+trailingComma: "es5"
+tabWidth: 2
+semi: true
+singleQuote: false
+singleAttributePerLine: true
+printWidth: 80
+arrowParens: avoid

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ const q = require("daskeyboard-applet");
 const { execSync } = require("child_process");
 const { logger } = q;
 const pingCountArg = process.platform === "win32" ? "-n" : "-c";
-const timeRe = / time=(\d+\.?\d*)\s?ms/gi;
+const timeRe = / time(\=|\<)(\d+\.?\d*)\s?ms/gi;
 
 function buildColorSteps({
   colorGood,
   colorBad,
   midSteps,
   pingThreshold,
-  stepGap
+  stepGap,
 }) {
   const totalSteps = midSteps + 2;
   const colorGoodRGB = hexToRGB(colorGood);
@@ -70,16 +70,7 @@ function hexToRGB(color) {
 }
 
 function rgbToHex(color) {
-  return (
-    "#" +
-    color
-      .map(n =>
-        Number(n)
-          .toString(16)
-          .padStart(2, "0")
-      )
-      .join("")
-  );
+  return "#" + color.map(n => Number(n).toString(16).padStart(2, "0")).join("");
 }
 
 class DasPing extends q.DesktopApp {
@@ -94,7 +85,7 @@ class DasPing extends q.DesktopApp {
       midSteps: parseInt(this.config.midSteps, 10) || 3,
       pingThreshold: parseInt(this.config.pingThreshold, 10) || 300,
       pollingInterval: parseInt(this.config.pollingInterval, 10) || 60000,
-      stepGap: parseInt(this.config.stepGap, 10) || 100
+      stepGap: parseInt(this.config.stepGap, 10) || 100,
     };
 
     this.colorSteps = buildColorSteps(this.config);
@@ -108,7 +99,7 @@ class DasPing extends q.DesktopApp {
 
     try {
       const output = execSync(`ping ${address} ${pingCountArg} 1`).toString();
-      var [, time] = timeRe.exec(output);
+      var [, , time] = timeRe.exec(output);
 
       // Reset exec index for next call
       timeRe.lastIndex = 0;
@@ -140,7 +131,7 @@ class DasPing extends q.DesktopApp {
     return new q.Signal({
       points: [[new q.Point(color)]],
       name: "Das Ping",
-      message
+      message,
     });
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,9 +13,9 @@ function getDefaultConfig(config) {
         pingThreshold: 300,
         pollingInterval: 60000,
         stepGap: 100,
-        ...config
-      }
-    }
+        ...config,
+      },
+    },
   };
 }
 
@@ -36,5 +36,41 @@ describe("Das Ping: #run()", () => {
 
     assert.ok(color);
     assert.notEqual(color, config.applet.defaults.colorFail);
+  });
+
+  it("successfully handles response time less than 1ms (<1ms).", async () => {
+    const config = getDefaultConfig({ address: "localhost" });
+
+    await App.processConfig(config);
+
+    const signal = await App.run();
+    const { color } = signal.points[0][0];
+
+    assert.ok(color);
+    assert.notEqual(color, config.applet.defaults.colorFail);
+  });
+
+  it("gracefully handles a failed ping due to dns resolution failure.", async () => {
+    const config = getDefaultConfig({ address: "HOPEFULLYTHISDOESNOTEXIST" });
+
+    await App.processConfig(config);
+
+    const signal = await App.run();
+    const { color } = signal.points[0][0];
+
+    assert.ok(color);
+    assert.equal(color, config.applet.defaults.colorFail);
+  });
+
+  it("gracefully handles a failed ping due to routing failure.", async () => {
+    const config = getDefaultConfig({ address: "0.0.0.0" });
+
+    await App.processConfig(config);
+
+    const signal = await App.run();
+    const { color } = signal.points[0][0];
+
+    assert.ok(color);
+    assert.equal(color, config.applet.defaults.colorFail);
   });
 });


### PR DESCRIPTION
In the case where a ping returns a latency of less than one millisecond the status should color-grade according to the provided configuration.

## The Problem
When the ping command is used against a hostname to which latency is very low e.g. localhost or default route the current implementation will consider the ping failed.

### Why?
When the latency is less than a millisecond the ping command will return a measurement in the form of `time<1ms`. Currently, the [regex](https://github.com/soluml/daskeyboard-applet--dasping/blob/b78d990c6bd64a19af69410721e1876f47a82b31/index.js#L5) used to extract the latency measurement assumes that the latency will always be in the form of `time=xms`. Therefore, when the latency is very, very low the regex will not match and is considered a failure.

#### Happy Path Output from `ping`:
```
> ping 8.8.8.8 -n 1

Pinging 8.8.8.8 with 32 bytes of data:
Reply from 8.8.8.8: bytes=32 time=46ms TTL=115

Ping statistics for 8.8.8.8:
    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
Approximate round trip times in milli-seconds:
    Minimum = 46ms, Maximum = 46ms, Average = 46ms
```

#### Failure Case Output from `ping`:
```
> ping 127.0.0.1 -n 1

Pinging 127.0.0.1 with 32 bytes of data:
Reply from 127.0.0.1: bytes=32 time<1ms TTL=128

Ping statistics for 127.0.0.1:
    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
Approximate round trip times in milli-seconds:
    Minimum = 0ms, Maximum = 0ms, Average = 0ms
```

### Potential Solution
Update the regex to match both `time=` and `time<` as proposed in this pull request.

### Sure, but that's a very unlikely use case
After writing this up I can see that perspective given my example of using `127.0.0.1`. It may seem weird that one would ping their local machine for a status when the status is shown on a device that one would be using on that machine when the status changes.

However, my actual use case is to ping two hosts:
 1. a known external ip (8.8.8.8)
 2. a known internal ip

Since my 'known internal ip' happens to be my primary network router - and as such is the default route on my machine - the latency recorded is very little. When I setup the monitoring I immediately realized that my local router would also show a failure status.

## Testing
 - I hand tested these changes using Das Keyboard Q version v3.3.3 on a Windows 11 machine.
 - Added some unit test cases.

## Bonuses
 - I added a `.prettierrc.yaml` file with values that closely match the existing patterns observed in this project in order to minimize the noise produced in this pull request by the [default prettier config values](https://prettier.io/docs/en/options.html). My editor is setup to always run prettier when I touch a file. Having the `.prettierrc.yaml` will ensure that all future prettier runs will format the code in the same way and reduce PR noise from others that may use prettier.
